### PR TITLE
Fix: Empty java files

### DIFF
--- a/src/main/java/gumtree/spoon/AstComparator.java
+++ b/src/main/java/gumtree/spoon/AstComparator.java
@@ -87,6 +87,11 @@ public class AstComparator {
 		compiler.getFactory().getEnvironment().setLevel("OFF");
 		compiler.addInputSource(SpoonResourceHelper.createResource(file));
 		compiler.build();
+
+		if (factory.Type().getAll().size() == 0) {
+			return null;
+		}
+
 		return factory.Type().getAll().get(0);
 	}
 


### PR DESCRIPTION
Empty java files used to throw an error when getting all factory Types.

It is now fixed.