### PR TITLE
fix: fix confusing debug toString for modifier Itree nodes which have no corresponding real Spoon node

### DIFF
--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -26,7 +26,6 @@ class NodeCreator extends CtInheritanceScanner {
 	@Override
 	public void scanCtModifiable(CtModifiable m) {
 		ITree modifiers = builder.createNode("Modifiers", "");
-		modifiers.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, m);
 
 		// ensuring an order (instead of hashset)
 		// otherwise some flaky tests in CI
@@ -40,7 +39,6 @@ class NodeCreator extends CtInheritanceScanner {
 
 		for (ModifierKind kind : modifiers1) {
 			ITree modifier = builder.createNode("Modifier", kind.toString());
-			modifier.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, m);
 			modifiers.addChild(modifier);
 		}
 		builder.addSiblingNode(modifiers);

--- a/src/main/java/gumtree/spoon/diff/Diff.java
+++ b/src/main/java/gumtree/spoon/diff/Diff.java
@@ -14,15 +14,16 @@ import spoon.reflect.declaration.CtElement;
 public interface Diff {
 
 	/**
+	 * lists all operations such that the parent is not involved in the diff
+	 */
+	List<Operation> getRootOperations();
+
+	/**
 	 * lists all operations (move,insert, deletes). Low-level operation, we
 	 * recommend using {@link #getRootOperations()}
 	 */
 	List<Operation> getAllOperations();
 
-	/**
-	 * lists all operations such that the parent is not involved in the diff
-	 */
-	List<Operation> getRootOperations();
 
 	/**
 	 * lists all operations sub the given parent operation.

--- a/src/main/java/gumtree/spoon/diff/operations/Operation.java
+++ b/src/main/java/gumtree/spoon/diff/operations/Operation.java
@@ -40,9 +40,15 @@ public abstract class Operation<T extends Action> {
 		String newline = System.getProperty("line.separator");
 		StringBuilder stringBuilder = new StringBuilder();
 
-		CtElement element = (CtElement) action.getNode().getMetadata(SpoonGumTreeBuilder.SPOON_OBJECT);
 		// action name
 		stringBuilder.append(action.getClass().getSimpleName());
+
+		CtElement element = node;
+
+		if (element == null) {
+			// some elements are only in the gumtree for having a clean diff but not in the Spoon metamodel
+			return stringBuilder.toString() + " fake_node(" + action.getNode().getMetadata("type") + ")";
+		}
 
 		// node type
 		String nodeType = element.getClass().getSimpleName();

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -59,6 +59,17 @@ public class AstComparatorTest {
 	}
 
 	@Test
+	public void testgetAllOperations() throws Exception{
+		AstComparator diff = new AstComparator();
+		CtElement left = diff.getCtType(new File("src/test/resources/examples/testDuplicateOperations/left.java"));
+		CtElement right = diff.getCtType(new File("src/test/resources/examples/testDuplicateOperations/right.java"));
+
+		Diff editScript = diff.compare(left, right);
+		List<Operation> allOperations = editScript.getAllOperations();
+		assertEquals(8, editScript.getAllOperations().size());
+	}
+
+	@Test
 	public void testAnalyzeStringString() {
 		String c1 = "" + "class X {" + "public void foo0() {" + " int x = 0;" + "}" + "};";
 

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -65,8 +65,11 @@ public class AstComparatorTest {
 		CtElement right = diff.getCtType(new File("src/test/resources/examples/testDuplicateOperations/right.java"));
 
 		Diff editScript = diff.compare(left, right);
-		List<Operation> allOperations = editScript.getAllOperations();
-		assertEquals(8, editScript.getAllOperations().size());
+		assertEquals(10, editScript.getAllOperations().size());
+		assertEquals(5, editScript.getRootOperations().size());
+		assertTrue(editScript.containsOperation(OperationKind.Insert, "Method", "print"));
+		assertTrue(editScript.containsOperation(OperationKind.Delete, "Method", "delete"));
+		assertTrue(editScript.containsOperation(OperationKind.Move, "Invocation"));
 	}
 
 	@Test

--- a/src/test/resources/examples/testDuplicateOperations/left.java
+++ b/src/test/resources/examples/testDuplicateOperations/left.java
@@ -1,0 +1,13 @@
+public class test{
+    void main(){
+        System.out.println("move");
+    }
+
+    void method(){
+        System.out.println("origin");
+    }
+
+    void delete(){
+
+    }
+}

--- a/src/test/resources/examples/testDuplicateOperations/right.java
+++ b/src/test/resources/examples/testDuplicateOperations/right.java
@@ -1,0 +1,13 @@
+public class test{
+    void main(){
+        print();
+    }
+
+    void print(){
+        System.out.println("move");
+    }
+
+    void method(){
+        System.out.println("update");
+    }
+}


### PR DESCRIPTION
add a failing test case for duplicate operations return by Diff.getAllOperations()