### PR TITLE
[issue] GTSpoon diff with intert / delete /move instead of insert only

### DIFF
--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import gumtree.spoon.builder.SpoonGumTreeBuilder;
 import gumtree.spoon.diff.Diff;
+import gumtree.spoon.diff.operations.InsertOperation;
 import gumtree.spoon.diff.operations.MoveOperation;
 import gumtree.spoon.diff.operations.Operation;
 import gumtree.spoon.diff.operations.OperationKind;
@@ -1616,4 +1617,17 @@ public class AstComparatorTest {
 		assertTrue(result.containsOperation(OperationKind.Delete, "Method"));
 	}
 
+
+	@Test
+	public void testComplexStr() throws Exception {
+		AstComparator comparator = new AstComparator();
+		File file0 = new File("src/test/resources/examples/testComplexStr/old.java");
+		File file1 = new File("src/test/resources/examples/testComplexStr/new.java");
+		Diff result = comparator.compare(file0, file1);
+
+		List<Operation> operations = result.getRootOperations();
+		for (Operation operation : operations) {
+			assertTrue(operation instanceof InsertOperation);
+		}
+	}
 }

--- a/src/test/resources/examples/testComplexStr/new.java
+++ b/src/test/resources/examples/testComplexStr/new.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.config.builder;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+public class ConfigurationBuilderTest {
+
+    private static final String INDENT = "  ";
+    private static final String EOL = System.lineSeparator();
+
+    private final static String expectedXml =
+            "a" + EOL +
+            "b" + EOL +
+            "c" + EOL;
+
+}

--- a/src/test/resources/examples/testComplexStr/old.java
+++ b/src/test/resources/examples/testComplexStr/old.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache license, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the license for the specific language governing permissions and
+ * limitations under the license.
+ */
+package org.apache.logging.log4j.core.config.builder;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+public class ConfigurationBuilderTest {
+
+    private static final String INDENT = "  ";
+    private static final String EOL = System.lineSeparator();
+
+    private final static String expectedXml =
+            "a" + EOL +
+            "c" + EOL;
+
+}


### PR DESCRIPTION
I added test case of comparing multi-lines Strings.

I can not find the reason why GTSpoon can not solve this case, but i believe it is one issue of GTSpoon rather than gumtree, as I tried the gumtree webdiff tool and got [the correct result](https://github.com/ycaxgjd/tmp/blob/master/Screen%20Shot%202019-03-06%20at%2019.10.22.png)