### PR TITLE
factory is set for CtWrapper and CtVirtualElement

### DIFF
--- a/src/main/java/gumtree/spoon/builder/CtWrapper.java
+++ b/src/main/java/gumtree/spoon/builder/CtWrapper.java
@@ -27,6 +27,7 @@ public class CtWrapper<L> extends CtElementImpl {
 		super();
 		this.value = wrapped;
 		this.parent = parent;
+		setFactory(parent.getFactory());
 	}
 
 	public CtWrapper(L wrapped, CtElement parent, CtRole roleInParent) {
@@ -34,6 +35,7 @@ public class CtWrapper<L> extends CtElementImpl {
 		this.value = wrapped;
 		this.parent = parent;
 		this.roleInParent = roleInParent;
+		setFactory(parent.getFactory());
 	}
 
 	@Override


### PR DESCRIPTION
This solves the NullPointerException mentioned in [this issue](https://github.com/SpoonLabs/coming/issues/177).

The problem with the old version is that the `factory` is not set for `CtWrapper` & `CtVirtualElement` instances. In this pull request, we set the same factory for such elements as the factory of their parents.