### PR TITLE
Added SLF4J to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,11 @@
       </exclusions>
       <scope>test</scope>
     </dependency>
-
+    <dependency> 
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.30</version>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>


### PR DESCRIPTION
Added SLF4J to `pom.xml` so that it doesn't show:

```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```