### PR TITLE
bump spoon core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,8 +36,7 @@
     <dependency>
       <groupId>fr.inria.gforge.spoon</groupId>
       <artifactId>spoon-core</artifactId>
-      <!-- must be set to X.Y.Z without -SNAPSHOT before releasing a new version --> 
-      <version>8.2.0-SNAPSHOT</version>
+      <version>8.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.gumtreediff</groupId>


### PR DESCRIPTION
Fixes #135 

Maven was not able to find the dependency version `8.2.0-SNAPSHOT` of spoon-core. These changes correct the version according to the instructions [here](http://spoon.gforge.inria.fr/#download).