### PR TITLE
Fix fetching of log4j jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,9 @@
             <manifest>
               <mainClass>gumtree.spoon.AstComparator</mainClass>
             </manifest>
+            <manifestEntries>
+              <Multi-Release>true</Multi-Release>
+            </manifestEntries>
           </archive>
           <descriptorRefs>
             <descriptorRef>jar-with-dependencies</descriptorRef>


### PR DESCRIPTION
Fixes #137 
Reference: https://stackoverflow.com/questions/52953483/logmanager-getlogger-is-unable-to-determine-class-name-on-java-11

`log4j` is a multi-release jar so running the project on Java 11 without `Multi-Release: true` wasn't working. Passing this flag instructed the runtime to get `log4j` compatible for version 11 which successfully executed the project.