### PR TITLE
Add test for asserting role of final modifier in a `CtField`

### DIFF
--- a/src/test/java/gumtree/spoon/builder/CtWrapperTest.java
+++ b/src/test/java/gumtree/spoon/builder/CtWrapperTest.java
@@ -1,0 +1,33 @@
+package gumtree.spoon.builder;
+
+import org.junit.Test;
+import spoon.reflect.declaration.CtClass;
+import spoon.reflect.declaration.CtField;
+import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.factory.Factory;
+import spoon.reflect.factory.FactoryImpl;
+import spoon.reflect.path.CtRole;
+import spoon.support.DefaultCoreFactory;
+import spoon.support.StandardEnvironment;
+
+import static org.junit.Assert.assertEquals;
+
+public class CtWrapperTest {
+    @Test
+    public void testRoleOfFinalInField() {
+        // the role of final modifier in a field should be CtRole.IS_FINAL
+
+        final Factory factory = new FactoryImpl(new DefaultCoreFactory(), new StandardEnvironment());
+        final CtClass<?> fieldClass = factory.Class().create("FieldClass");
+
+        final CtField<String> field = factory.Core().createField();
+        field.setType(factory.Type().STRING);
+        field.setSimpleName("FIELD");
+
+        CtWrapper<?> modifier = new CtWrapper<>(ModifierKind.FINAL, field);
+
+        fieldClass.addField(field);
+
+        assertEquals(CtRole.IS_FINAL, modifier.getRoleInParent());
+    }
+}


### PR DESCRIPTION
These changes add a test to assert that role of `ModifierKind.FINAL` in a `CtField` should be `CtRole.IS_FINAL`. However, this is not the case currently. `modifier.getRoleInParent()` returns `CtRole.TYPE_MEMBER` instead.

This _probable_ bug came as a result of running [this diff](https://github.com/KTH/spork/commit/1f2661b#diff-093f42e435ce93da0fbace7309766d5a0bff06f30a8b3d07a2627f8b3cb3280eR44) through `diffmin`. The operation my code broke on was an `InsertOperation` (`Insert Wra at se.kth.spork.spoon.pcsinterpreter.SpoonTreeBuilder`) as it tried to compute `srcNodeParent.getValueByRole(srcNode.getRoleInParent()`.

where,
- `srcNodeParent` is a `CtField` instance
- `srcNode` is a `CtWrapper` instance

Now, `getValueByRole` throws an exception because a `CtField` cannot have type members. It can have a `CtRole.TYPE` (`SpoonMapping` in this case). And it should have had a `CtRole.IS_FINAL`, but I am not sure what `getValueByRole` should return in that case. It can probably return a boolean but let's decide this later on. 

Please note that I might be wrong in my assumption, so I have only added a test case and not a fix. Once this is approved, I shall move forward.