### PR TITLE
Fix role of `CtWrapper` elements in their parent

### DIFF
--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -36,7 +36,7 @@ public class NodeCreator extends CtInheritanceScanner {
 		ITree modifiers = builder.createNode(type, "");
 
 		// We create a virtual node
-		modifiers.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, new CtVirtualElement(type, m, m.getModifiers()));
+		modifiers.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, new CtVirtualElement(type, m, m.getModifiers(), CtRole.MODIFIER));
 
 		// ensuring an order (instead of hashset)
 		// otherwise some flaky tests in CI

--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -52,7 +52,7 @@ public class NodeCreator extends CtInheritanceScanner {
 			ITree modifier = builder.createNode("Modifier", kind.toString());
 			modifiers.addChild(modifier);
 			// We wrap the modifier (which is not a ctelement)
-			modifier.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, new CtWrapper(kind, m));
+			modifier.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, new CtWrapper(kind, m, CtRole.MODIFIER));
 		}
 		builder.addSiblingNode(modifiers);
 

--- a/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
+++ b/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import gumtree.spoon.builder.CtVirtualElement;
+import gumtree.spoon.builder.CtWrapper;
 import org.junit.Test;
 
 import com.github.gumtreediff.tree.ITree;
@@ -18,6 +20,7 @@ import gumtree.spoon.diff.operations.Operation;
 import gumtree.spoon.diff.operations.UpdateOperation;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 
 import java.io.File;
@@ -173,9 +176,9 @@ public class SpoonSupportTest {
 
 		Diff diff = new AstComparator().compare(fl, fr);
 
-		CtElement insertedFinalNode = diff.getRootOperations().get(0).getSrcNode();
+		CtWrapper<?> finalNode = (CtWrapper<?>) diff.getRootOperations().get(0).getSrcNode();
 
-		assertEquals(CtRole.MODIFIER, insertedFinalNode.getRoleInParent());
+		assertEquals(CtRole.MODIFIER, finalNode.getRoleInParent());
 	}
 
 	@Test
@@ -185,8 +188,8 @@ public class SpoonSupportTest {
 
 		Diff diff = new AstComparator().compare(fl, fr);
 
-		CtElement insertedFinalNode = diff.getRootOperations().get(0).getSrcNode();
+		CtVirtualElement modifiers = (CtVirtualElement) diff.getRootOperations().get(0).getSrcNode();
 
-		assertEquals(CtRole.MODIFIER, insertedFinalNode.getRoleInParent());
+		assertEquals(CtRole.MODIFIER, modifiers.getRoleInParent());
 	}
 }

--- a/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
+++ b/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
@@ -167,7 +167,19 @@ public class SpoonSupportTest {
 	}
 
 	@Test
-	public void testRoleOfModifierInParent() throws Exception {
+	public void testRoleOfFinalInParent() throws Exception {
+		File fl = new File("src/test/resources/examples/roleInParent/final/left.java");
+		File fr = new File("src/test/resources/examples/roleInParent/final/right.java");
+
+		Diff diff = new AstComparator().compare(fl, fr);
+
+		CtElement insertedFinalNode = diff.getRootOperations().get(0).getSrcNode();
+
+		assertEquals(CtRole.MODIFIER, insertedFinalNode.getRoleInParent());
+	}
+
+	@Test
+	public void testRoleOfModifiersInParent() throws Exception {
 		File fl = new File("src/test/resources/examples/roleInParent/modifiers/left.java");
 		File fr = new File("src/test/resources/examples/roleInParent/modifiers/right.java");
 

--- a/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
+++ b/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
@@ -16,7 +16,11 @@ import gumtree.spoon.diff.operations.DeleteOperation;
 import gumtree.spoon.diff.operations.InsertOperation;
 import gumtree.spoon.diff.operations.Operation;
 import gumtree.spoon.diff.operations.UpdateOperation;
+import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
+import spoon.reflect.path.CtRole;
+
+import java.io.File;
 
 public class SpoonSupportTest {
 
@@ -162,4 +166,15 @@ public class SpoonSupportTest {
 
 	}
 
+	@Test
+	public void testRoleOfModifierInParent() throws Exception {
+		File fl = new File("src/test/resources/examples/roleInParent/modifiers/left.java");
+		File fr = new File("src/test/resources/examples/roleInParent/modifiers/right.java");
+
+		Diff diff = new AstComparator().compare(fl, fr);
+
+		CtElement insertedFinalNode = diff.getRootOperations().get(0).getSrcNode();
+
+		assertEquals(CtRole.MODIFIER, insertedFinalNode.getRoleInParent());
+	}
 }

--- a/src/test/resources/examples/roleInParent/final/left.java
+++ b/src/test/resources/examples/roleInParent/final/left.java
@@ -1,0 +1,3 @@
+class Final {
+    private static int x;
+}

--- a/src/test/resources/examples/roleInParent/final/right.java
+++ b/src/test/resources/examples/roleInParent/final/right.java
@@ -1,3 +1,3 @@
-class Modifiers {
+class Final {
     private static final int x;
 }

--- a/src/test/resources/examples/roleInParent/modifiers/left.java
+++ b/src/test/resources/examples/roleInParent/modifiers/left.java
@@ -1,0 +1,3 @@
+class Final {
+    private static int x;
+}

--- a/src/test/resources/examples/roleInParent/modifiers/left.java
+++ b/src/test/resources/examples/roleInParent/modifiers/left.java
@@ -1,3 +1,3 @@
-class Final {
-    private static int x;
+class Modifiers {
+    int x;
 }

--- a/src/test/resources/examples/roleInParent/modifiers/right.java
+++ b/src/test/resources/examples/roleInParent/modifiers/right.java
@@ -1,0 +1,3 @@
+class Final {
+    private static final int x;
+}


### PR DESCRIPTION
Fixes #160 

These changes explicitly assign `roleInParent` to the following elements.
- [x] Complete collection of modifier (`CtVirtualElement`)
- [x] Individual modifiers (`CtWrapper`)
- ~[ ] Super type~

I am not sure how I can test for the role of a `CtTypeReference` (`SUPER_TYPE` in this case). Need some help there.