### PR TITLE
Add API to retrieve children of `CtVirtualElement`

### DIFF
--- a/src/main/java/gumtree/spoon/builder/CtVirtualElement.java
+++ b/src/main/java/gumtree/spoon/builder/CtVirtualElement.java
@@ -1,6 +1,7 @@
 package gumtree.spoon.builder;
 
 import java.util.Collection;
+import java.util.Collections;
 
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
@@ -26,7 +27,7 @@ public class CtVirtualElement extends CtWrapper<String> {
 	}
 
 	public Collection<?> getChildren() {
-		return children;
+		return Collections.unmodifiableCollection(children);
 	}
 
 	@Override

--- a/src/main/java/gumtree/spoon/builder/CtVirtualElement.java
+++ b/src/main/java/gumtree/spoon/builder/CtVirtualElement.java
@@ -25,6 +25,10 @@ public class CtVirtualElement extends CtWrapper<String> {
 		this.children = children;
 	}
 
+	public Collection<?> getChildren() {
+		return children;
+	}
+
 	@Override
 	public String toString() {
 		return "VE: " + ((value != null) ? (value.toString()) : null);

--- a/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
+++ b/src/test/java/gumtree/spoon/diff/support/SpoonSupportTest.java
@@ -24,6 +24,8 @@ import spoon.reflect.declaration.ModifierKind;
 import spoon.reflect.path.CtRole;
 
 import java.io.File;
+import java.util.HashSet;
+import java.util.Set;
 
 public class SpoonSupportTest {
 
@@ -191,5 +193,25 @@ public class SpoonSupportTest {
 		CtVirtualElement modifiers = (CtVirtualElement) diff.getRootOperations().get(0).getSrcNode();
 
 		assertEquals(CtRole.MODIFIER, modifiers.getRoleInParent());
+	}
+
+	@Test
+	public void testGettingChildrenOfCtVirtualElement() {
+		String c1 = "class Test { }";
+		String c2 = "public abstract final class Test { }";
+
+		Diff editScript = new AstComparator().compare(c1, c2);
+
+		CtVirtualElement srcNode = (CtVirtualElement) editScript.getRootOperations().get(0).getSrcNode();
+		Set<?> modifiers = new HashSet<>(srcNode.getChildren());
+
+		Set<ModifierKind> expectedModifiers = new HashSet<>();
+		expectedModifiers.add(ModifierKind.PUBLIC);
+		expectedModifiers.add(ModifierKind.ABSTRACT);
+		expectedModifiers.add(ModifierKind.FINAL);
+
+
+		assertEquals(3, modifiers.size());
+		assertTrue(modifiers.containsAll(expectedModifiers));
 	}
 }


### PR DESCRIPTION
Fixes #162 

- Did not write a test case as the API is not _computing_ anything. It just returns the `children`. We could test for visibility but I think that is out of scope.
- I hope the API name `getChildren()` is not confused with `getDirectChildren()` in spoon. If that is the case, I am open to suggestion for a better name. 