### PR TITLE
add feature getUpdateOperations() (and ostracize update operations from root operations)

### DIFF
--- a/src/main/java/gumtree/spoon/diff/ActionClassifier.java
+++ b/src/main/java/gumtree/spoon/diff/ActionClassifier.java
@@ -96,6 +96,7 @@ public class ActionClassifier {
 	}
 
 	public List<Action> getUpdateActions() {
+		// new method
 		return srcUpdTrees.stream().map(t -> originalActionsSrc.get(t)).collect(Collectors.toList());
 	}
 

--- a/src/main/java/gumtree/spoon/diff/ActionClassifier.java
+++ b/src/main/java/gumtree/spoon/diff/ActionClassifier.java
@@ -74,16 +74,15 @@ public class ActionClassifier {
 	 * This method retrieves ONLY the ROOT actions
 	 */
 	public List<Action> getRootActions() {
-		final List<Action> rootActions = srcUpdTrees.stream().map(t -> originalActionsSrc.get(t))
-				.collect(Collectors.toList());
+		final List<Action> rootActions = new ArrayList<>();
 
 		rootActions.addAll(srcDelTrees.stream() //
-				.filter(t -> !srcDelTrees.contains(t.getParent()) && !srcUpdTrees.contains(t.getParent())) //
+				.filter(t -> !srcDelTrees.contains(t.getParent())) //
 				.map(t -> originalActionsSrc.get(t)) //
 				.collect(Collectors.toList()));
 
 		rootActions.addAll(dstAddTrees.stream() //
-				.filter(t -> !dstAddTrees.contains(t.getParent()) && !dstUpdTrees.contains(t.getParent())) //
+				.filter(t -> !dstAddTrees.contains(t.getParent())) //
 				.map(t -> originalActionsDst.get(t)) //
 				.collect(Collectors.toList()));
 
@@ -94,6 +93,10 @@ public class ActionClassifier {
 
 		rootActions.removeAll(Collections.singleton(null));
 		return rootActions;
+	}
+
+	public List<Action> getUpdateActions() {
+		return srcUpdTrees.stream().map(t -> originalActionsSrc.get(t)).collect(Collectors.toList());
 	}
 
 	private void clean() {

--- a/src/main/java/gumtree/spoon/diff/Diff.java
+++ b/src/main/java/gumtree/spoon/diff/Diff.java
@@ -19,6 +19,11 @@ public interface Diff {
 	List<Operation> getRootOperations();
 
 	/**
+	 * lists all the update operations
+	 */
+	List<Operation> getUpdateOperations();
+
+	/**
 	 * lists all operations (move,insert, deletes). Low-level operation, we
 	 * recommend using {@link #getRootOperations()}
 	 */

--- a/src/main/java/gumtree/spoon/diff/DiffImpl.java
+++ b/src/main/java/gumtree/spoon/diff/DiffImpl.java
@@ -41,6 +41,10 @@ public class DiffImpl implements Diff {
 	 */
 	private final List<Operation> rootOperations;
 	/**
+	 * Actions over updated nodes.
+	 */
+	private final List<Operation> updateOperations;
+	/**
 	 * the mapping of this diff
 	 */
 	private final MappingStore _mappingsComp;
@@ -68,6 +72,7 @@ public class DiffImpl implements Diff {
 		// Bugfix: the Action classifier must be executed *BEFORE* the convertToSpoon
 		// because it writes meta-data on the trees
 		this.rootOperations = convertToSpoon(actionClassifier.getRootActions());
+		this.updateOperations = convertToSpoon(actionClassifier.getUpdateActions());
 		this.allOperations = convertToSpoon(actionGenerator.getActions());
 
 		this._mappingsComp = mappingsComp;
@@ -111,6 +116,11 @@ public class DiffImpl implements Diff {
 	@Override
 	public List<Operation> getRootOperations() {
 		return Collections.unmodifiableList(rootOperations);
+	}
+
+	@Override
+	public List<Operation> getUpdateOperations() {
+		return Collections.unmodifiableList(updateOperations);
 	}
 
 	@Override

--- a/src/main/java/gumtree/spoon/diff/operations/UpdateOperation.java
+++ b/src/main/java/gumtree/spoon/diff/operations/UpdateOperation.java
@@ -1,21 +1,41 @@
 package gumtree.spoon.diff.operations;
 
-import com.github.gumtreediff.actions.model.Action;
 import com.github.gumtreediff.actions.model.Update;
 import gumtree.spoon.builder.SpoonGumTreeBuilder;
+import spoon.reflect.code.CtBinaryOperator;
+import spoon.reflect.code.CtInvocation;
+import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtElement;
+import spoon.reflect.path.CtRole;
 
 public class UpdateOperation extends Operation<Update> {
 	private final CtElement destElement;
+	private final CtRole role;
 
 	public UpdateOperation(Update action) {
 		super(action);
 		destElement = (CtElement) action.getNode().getMetadata(SpoonGumTreeBuilder.SPOON_OBJECT_DEST);
+		if (destElement instanceof CtBinaryOperator<?>) {
+			role = CtRole.OPERATOR_KIND;
+		}
+		else if (destElement instanceof CtInvocation<?>) {
+			role = CtRole.EXECUTABLE_REF;
+		}
+		else if (destElement instanceof CtLiteral<?>) {
+			role = CtRole.VALUE;
+		}
+		else {
+			role = CtRole.NAME;;
+		}
 	}
 
 	@Override
 	public CtElement getDstNode() {
 		return destElement;
+	}
+
+	public CtRole getRole() {
+		return role;
 	}
 
 }

--- a/src/test/java/gumtree/spoon/diff/UpdateOperationTest.java
+++ b/src/test/java/gumtree/spoon/diff/UpdateOperationTest.java
@@ -1,0 +1,77 @@
+package gumtree.spoon.diff;
+
+import static org.junit.Assert.assertEquals;
+
+import gumtree.spoon.AstComparator;
+import gumtree.spoon.diff.operations.UpdateOperation;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import spoon.reflect.path.CtRole;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@RunWith(Parameterized.class)
+public class UpdateOperationTest {
+    @Parameters(name = "{2}")
+    public static Collection<Object[]> provideTestStringsAndExpectedRole() {
+        return Arrays.asList(new Object[][] {
+                {
+                        "class A { public void B() { System.out.println(1+1) } }",
+                        "class A { public void B() { System.out.println(2+1) } }",
+                        CtRole.VALUE,
+                },
+                {
+                        "class A { public void B() { System.out.println(1+1) } }",
+                        "class A { public void B() { System.out.println(1-1) } }",
+                        CtRole.OPERATOR_KIND,
+                },
+                {
+                        "class A { public void B() { System.exit() } }",
+                        "class A { public void B() { System.out.println(\"Nothing.\") } }",
+                        CtRole.EXECUTABLE_REF,
+                },
+                {
+                        "class A { }",
+                        "class B { }",
+                        CtRole.NAME,
+                },
+                {
+                        "class A { void add() { } }",
+                        "class A { void sub() { } }",
+                        CtRole.NAME,
+                },
+                {
+                        "class A { void add() { } }",
+                        "class A { int add() { } }",
+                        CtRole.NAME,
+                },
+                {
+                        "public class A { }",
+                        "private class A { }",
+                        CtRole.MODIFIER,
+                },
+        });
+    }
+
+    private final String left;
+    private final String right;
+    private final CtRole expectedRole;
+
+    public UpdateOperationTest(String left, String right, CtRole expectedRole) {
+        this.left = left;
+        this.right = right;
+        this.expectedRole = expectedRole;
+    }
+
+    @Test
+    public void test_roleOfUpdatedNode() {
+        Diff diff = new AstComparator().compare(left, right);
+        assertEquals(1, diff.getUpdateOperations().size());
+
+        UpdateOperation updateOperation = (UpdateOperation) diff.getUpdateOperations().get(0);
+        assertEquals(expectedRole, updateOperation.getRole());
+    }
+}


### PR DESCRIPTION
Fixes #125 

A prototype of solution proposed [here](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/125#issuecomment-864620236). The other tests are failing because the update operation is no longer a root operation so I will try to fix the test cases in future commits.

Also, we need a _smarter_ way to identity the `CtRole` of the updated node because the current solution may culminate into a huge `if-else`. 