### PR TITLE
fix: add generic type paramaters of variables in ITree

### DIFF
--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -71,6 +71,12 @@ public class NodeCreator extends CtInheritanceScanner {
 			ITree variableType = builder.createNode("VARIABLE_TYPE", type.getQualifiedName());
 			variableType.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, type);
 			type.putMetadata(SpoonGumTreeBuilder.GUMTREE_NODE, variableType);
+			for (CtTypeReference<?> typeArgument: type.getActualTypeArguments()) {
+				ITree arg = builder.createNode(getClassName(typeArgument.getClass().getSimpleName()), typeArgument.getQualifiedName());
+				arg.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, typeArgument);
+				typeArgument.putMetadata(SpoonGumTreeBuilder.GUMTREE_NODE, arg);
+				variableType.addChild(arg);
+			}
 			builder.addSiblingNode(variableType);
 		}
 	}

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2053,4 +2053,36 @@ public class AstComparatorTest {
 
 	}
 
+	@Test
+	public void test_diffOfGenericTypeReference_builtInTypeToBuiltInType() throws Exception {
+		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/left.java");
+		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeReference"));
+		assertTrue(diff.containsOperation(OperationKind.Insert, "WildcardReference"));
+	}
+
+	@Test
+	public void test_diffOfGenericTypeReference_builtInTypeToTypeParameter() throws Exception {
+		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/left.java");
+		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeReference"));
+		assertTrue(diff.containsOperation(OperationKind.Insert, "TypeParameterReference"));
+	}
+
+	@Test
+	public void test_diffOfGenericTypeReference_typeParameterToBuiltInType() throws Exception {
+		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/left.java");
+		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Insert, "TypeReference"));
+		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeParameterReference"));
+	}
 }

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2052,37 +2052,4 @@ public class AstComparatorTest {
 		assertEquals(deleteOpt.get().getNode().toString(), moveOpt.get().getNode().toString());
 
 	}
-
-	@Test
-	public void test_diffOfGenericTypeReference_builtInTypeToBuiltInType() throws Exception {
-		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/left.java");
-		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/right.java");
-
-		Diff diff = new AstComparator().compare(left, right);
-		assertEquals(2, diff.getRootOperations().size());
-		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeReference"));
-		assertTrue(diff.containsOperation(OperationKind.Insert, "WildcardReference"));
-	}
-
-	@Test
-	public void test_diffOfGenericTypeReference_builtInTypeToTypeParameter() throws Exception {
-		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/left.java");
-		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/right.java");
-
-		Diff diff = new AstComparator().compare(left, right);
-		assertEquals(2, diff.getRootOperations().size());
-		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeReference"));
-		assertTrue(diff.containsOperation(OperationKind.Insert, "TypeParameterReference"));
-	}
-
-	@Test
-	public void test_diffOfGenericTypeReference_typeParameterToBuiltInType() throws Exception {
-		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/left.java");
-		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/right.java");
-
-		Diff diff = new AstComparator().compare(left, right);
-		assertEquals(2, diff.getRootOperations().size());
-		assertTrue(diff.containsOperation(OperationKind.Insert, "TypeReference"));
-		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeParameterReference"));
-	}
 }

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -1541,7 +1541,7 @@ public class AstComparatorTest {
 		CtClass c2 = Launcher.parseClass("class BehaviorCall implements Call {\n"
 				+ "final AtomicReference failureRef = new AtomicReference<>();\n"
 				+ "final CountDownLatch latch = new CountDownLatch(1);\n" + "enqueue(new Callback() {\n"
-				+ "@override public void onResponse(Call call, Response response) {\n" + "responseRef.set(response);\n"
+				+ "@Override public void onResponse(Call call, Response<T> response) {\n" + "responseRef.set(response);\n"
 				+ "latch.countDown();\n" + "}\n" + "}\n" + ")\n" + "}");
 
 		AstComparator diff = new AstComparator();
@@ -1733,7 +1733,7 @@ public class AstComparatorTest {
 				+ "final AtomicReference failureRef = new AtomicReference<>();\n"
 				+ "final CountDownLatch latch = new CountDownLatch(1);\n" + "enqueue(new Callback() {\n"
 				// Here the difference
-				+ "@override public void onResponse(Call call, Response response) {\n" + "responseRef.set(response);\n"
+				+ "@Override public void onResponse(Call call, Response<T> response) {\n" + "responseRef.set(response);\n"
 				+ "latch.countDown();\n" + "}\n" + "}\n" + ")\n" + "}");
 
 		AstComparator diff = new AstComparator();

--- a/src/test/java/gumtree/spoon/diff/DiffTest.java
+++ b/src/test/java/gumtree/spoon/diff/DiffTest.java
@@ -170,7 +170,7 @@ public class DiffTest {
 		CtClass c2b = Launcher.parseClass("class BehaviorCall implements Call {\n"
 				+ "final AtomicReference failureRef = new AtomicReference<>();\n"
 				+ "final CountDownLatch latch = new CountDownLatch(1);\n" + "\n" + " enqueue(new Callback<T>() {\n"
-				+ "@override public void onResponse(Response response) {\n"
+				+ "@Override public void onResponse(Response<T> response) {\n"
 
 				// Added
 				+ "System.out.println();"

--- a/src/test/java/gumtree/spoon/diff/DiffTest.java
+++ b/src/test/java/gumtree/spoon/diff/DiffTest.java
@@ -197,4 +197,36 @@ public class DiffTest {
 
 	}
 
+	@Test
+	public void test_diffOfGenericTypeReference_builtInTypeToBuiltInType() throws Exception {
+		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/left.java");
+		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeReference"));
+		assertTrue(diff.containsOperation(OperationKind.Insert, "WildcardReference"));
+	}
+
+	@Test
+	public void test_diffOfGenericTypeReference_builtInTypeToTypeParameter() throws Exception {
+		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/left.java");
+		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeReference"));
+		assertTrue(diff.containsOperation(OperationKind.Insert, "TypeParameterReference"));
+	}
+
+	@Test
+	public void test_diffOfGenericTypeReference_typeParameterToBuiltInType() throws Exception {
+		File left = new File("src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/left.java");
+		File right = new File("src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Insert, "TypeReference"));
+		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeParameterReference"));
+	}
 }

--- a/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/left.java
+++ b/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/left.java
@@ -1,0 +1,5 @@
+import java.util.List;
+
+class Example {
+    private List<String> words;
+}

--- a/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/right.java
+++ b/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToBuiltInType/right.java
@@ -1,0 +1,5 @@
+import java.util.List;
+
+class Example {
+    private List<? super Integer> words;
+}

--- a/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/left.java
+++ b/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/left.java
@@ -1,0 +1,5 @@
+import java.util.Map;
+
+class Example<A, B> {
+    private Map<A, String> map;
+}

--- a/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/right.java
+++ b/src/test/resources/examples/diffOfGenericTypeReferences/builtInTypeToTypeParameter/right.java
@@ -1,0 +1,5 @@
+import java.util.Map;
+
+class Example<A, B> {
+    private Map<A, B> map;
+}

--- a/src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/left.java
+++ b/src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/left.java
@@ -1,0 +1,5 @@
+import java.util.Map;
+
+class Example<A> {
+    private Map<A, String> map;
+}

--- a/src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/right.java
+++ b/src/test/resources/examples/diffOfGenericTypeReferences/typeParameterToBuiltInType/right.java
@@ -1,0 +1,5 @@
+import java.util.Map;
+
+class Example<A> {
+    private Map<Integer, String> map;
+}


### PR DESCRIPTION
Fixes #157 

These changes would now allow the parser to detect generic types arguments. For example, `List<Integer>` -> `List<String>` or `SomeClass<A>` -> `SomeClass<B>`. In fact, this change discovered a bug in three of the existing test cases!
1. [test_issue201812](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/test/java/gumtree/spoon/AstComparatorTest.java#L1533)
2. [testModIfEmpty](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/test/java/gumtree/spoon/AstComparatorTest.java#L1724)
3. [test_action_RootOrder](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/test/java/gumtree/spoon/diff/DiffTest.java#L161)

**Missing operations** in each of them
1. [Delete TypeReference T](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/test/java/gumtree/spoon/AstComparatorTest.java#L1544)
2. [Delete TypeReference T](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/test/java/gumtree/spoon/AstComparatorTest.java#L1736)
3. [Delete TypeReference T](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/test/java/gumtree/spoon/diff/DiffTest.java#L173)

> There is a `Response` type reference in each of them which take a type parameter `T`. That was not being detected before.

However, this PR solves this problem but not completely. Elements like `List<List<String>>` still cannot be parsed. This is probably because we are _ending the visit_ of a `CtVariable` in `scanCtVariable`. We might need to redesign some aspects of the scanner so that all type arguments are parsed recursively. I will open another issue to elaborate on that.