### PR TITLE
fix: add labels in nodes for annotation

### DIFF
--- a/src/main/java/gumtree/spoon/builder/LabelFinder.java
+++ b/src/main/java/gumtree/spoon/builder/LabelFinder.java
@@ -19,10 +19,13 @@ import spoon.reflect.code.CtTypeAccess;
 import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.code.CtWhile;
+import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
+
+import java.lang.annotation.Annotation;
 
 class LabelFinder extends CtInheritanceScanner {
 	public String label = "";
@@ -143,5 +146,10 @@ class LabelFinder extends CtInheritanceScanner {
 	@Override
 	public void visitCtComment(CtComment comment) {
 		label = comment.getContent();
+	}
+
+	@Override
+	public <T extends Annotation> void visitCtAnnotation(CtAnnotation<T> annotation) {
+		label = annotation.toString();
 	}
 }

--- a/src/test/java/gumtree/spoon/TreeTest.java
+++ b/src/test/java/gumtree/spoon/TreeTest.java
@@ -511,4 +511,18 @@ public class TreeTest {
 		assertEquals(3, position.getLine());
 
 	}
+
+	@Test
+	public void test_getTree_labelExistsForAnnotations() {
+		String codeWithAnnotation = "class A { @Override public boolean equals(Object obj) { return false; }";
+
+		AstComparator comparator = new AstComparator();
+		CtType<?> spoonType = comparator.getCtType(codeWithAnnotation);
+
+		final SpoonGumTreeBuilder scanner = new SpoonGumTreeBuilder();
+		ITree root = scanner.getTree(spoonType);
+
+		ITree annotationNode = root.getChild(0).getChild(0).getChild(2);
+		assertEquals("@java.lang.Override", annotationNode.getLabel());
+	}
 }

--- a/src/test/java/gumtree/spoon/diff/DiffTest.java
+++ b/src/test/java/gumtree/spoon/diff/DiffTest.java
@@ -229,4 +229,15 @@ public class DiffTest {
 		assertTrue(diff.containsOperation(OperationKind.Insert, "TypeReference"));
 		assertTrue(diff.containsOperation(OperationKind.Delete, "TypeParameterReference"));
 	}
+
+	@Test
+	public void test_diffOfAnnotations() throws Exception {
+		File left = new File("src/test/resources/examples/annotations/left.java");
+		File right = new File("src/test/resources/examples/annotations/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+
+		assertEquals(1, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Update, "Annotation"));
+	}
 }

--- a/src/test/resources/examples/annotations/left.java
+++ b/src/test/resources/examples/annotations/left.java
@@ -1,0 +1,6 @@
+class Test {
+    @Override
+    public int hashCode() {
+        return -1;
+    }
+}

--- a/src/test/resources/examples/annotations/right.java
+++ b/src/test/resources/examples/annotations/right.java
@@ -1,0 +1,6 @@
+class Test {
+    @Deprecated
+    public int hashCode() {
+        return -1;
+    }
+}


### PR DESCRIPTION
Fixes #174 

The changes add a visitor for `CtAnnotation` which gets the corresponding label.