### PR TITLE
fix: retrieval of string representation of operation

### DIFF
--- a/src/main/java/gumtree/spoon/diff/operations/Operation.java
+++ b/src/main/java/gumtree/spoon/diff/operations/Operation.java
@@ -6,7 +6,6 @@ import com.github.gumtreediff.actions.model.Update;
 
 import gumtree.spoon.builder.SpoonGumTreeBuilder;
 import spoon.reflect.cu.position.NoSourcePosition;
-import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtPackage;
 import spoon.reflect.declaration.CtType;
@@ -69,11 +68,11 @@ public abstract class Operation<T extends Action> {
 		}
 		if (action instanceof Move) {
 			CtElement elementDest = (CtElement) action.getNode().getMetadata(SpoonGumTreeBuilder.SPOON_OBJECT_DEST);
-			position = " from " + element.getParent(CtClass.class).getQualifiedName();
+			position = " from " + element.getParent(CtType.class).getQualifiedName();
 			if (element.getPosition() != null && !(element.getPosition() instanceof NoSourcePosition)) {
 				position += ":" + element.getPosition().getLine();
 			}
-			position += " to " + elementDest.getParent(CtClass.class).getQualifiedName();
+			position += " to " + elementDest.getParent(CtType.class).getQualifiedName();
 			if (elementDest.getPosition() != null && !(elementDest.getPosition() instanceof NoSourcePosition)) {
 				position += ":" + elementDest.getPosition().getLine();
 			}


### PR DESCRIPTION
Initially, `Operation.toString()` would throw a `NullPointerException` because it tried to get the qualified name of the class its node belongs to. But it is not necessary that a Java file always has a class, and it may also have an interface. Thus, it's better to get `CtType`'s qualified name so that interface and classed both are accounted for.