### PR TITLE
fix: add support for parsing nested types in `RETURN_TYPE`

### DIFF
--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -124,6 +124,7 @@ public class NodeCreator extends CtInheritanceScanner {
 			ITree returnType = builder.createNode("RETURN_TYPE", type.getQualifiedName());
 			returnType.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, type);
 			type.putMetadata(SpoonGumTreeBuilder.GUMTREE_NODE, returnType);
+			computeTreeOfTypeReferences(type, returnType);
 			builder.addSiblingNode(returnType);
 		}
 

--- a/src/test/java/gumtree/spoon/TreeTest.java
+++ b/src/test/java/gumtree/spoon/TreeTest.java
@@ -568,4 +568,17 @@ public class TreeTest {
 
 		assertEquals(3, superInterfaces.getDescendants().size());
 	}
+
+	@Test
+	public void test_nestedReturnTypeOfMethodShouldGetParsed() throws Exception {
+		File file = new File("src/test/resources/examples/NestedReturnType.java");
+		AstComparator comparator = new AstComparator();
+		SpoonGumTreeBuilder scanner = new SpoonGumTreeBuilder();
+		ITree root = scanner.getTree(comparator.getCtType(file));
+		ITree method = root.getDescendants().stream().filter(iTree -> iTree.getLabel().equals("getIntegers")).findFirst().get();
+
+		ITree returnType = method.getChild(0);
+		assertEquals(1, returnType.getDescendants().size());
+		assertEquals("java.lang.Integer", returnType.getChild(0).getLabel());
+	}
 }

--- a/src/test/resources/examples/NestedReturnType.java
+++ b/src/test/resources/examples/NestedReturnType.java
@@ -1,0 +1,8 @@
+import java.util.ArrayList;
+import java.util.List;
+
+class NestedReturnType {
+    List<Integer> getIntegers() {
+        return new ArrayList<Integer>();
+    }
+}


### PR DESCRIPTION
Reference: #183 

`RETURN_TYPE` couldn't be added to `TreeScanner` give its dependency on `computeTreeOfTypeReferences` which is in `NodeCreator`.