### PR TITLE
fix: change label of root node of super interface for better performance

### DIFF
--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -96,9 +96,8 @@ public class NodeCreator extends CtInheritanceScanner {
 		}
 
 		// create the root super interface node whose children will be *actual* spoon nodes of interfaces
-		String typeLabel = "SuperInterfaces";
-		ITree superInterfaceRoot = builder.createNode("SUPER_INTERFACES", typeLabel);
-		String virtualNodeDescription = typeLabel + "_" + typeReference.getQualifiedName();
+		ITree superInterfaceRoot = builder.createNode("SUPER_INTERFACES", "");
+		String virtualNodeDescription = "SuperInterfaces_" + typeReference.getQualifiedName();
 		superInterfaceRoot.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, new CtVirtualElement(virtualNodeDescription, (CtElement) typeReference, typeReference.getSuperInterfaces(), CtRole.INTERFACE));
 
 		// attach each super interface to the root created above

--- a/src/test/java/gumtree/spoon/diff/DiffTest.java
+++ b/src/test/java/gumtree/spoon/diff/DiffTest.java
@@ -296,7 +296,7 @@ public class DiffTest {
 
 		// assert that only the root of super interfaces is inserted
 		assertEquals(1, diff.getRootOperations().size());
-		assertTrue(diff.containsOperation(OperationKind.Insert, "SUPER_INTERFACES", "SuperInterfaces"));
+		assertTrue(diff.containsOperation(OperationKind.Insert, "SUPER_INTERFACES"));
 
 		// verify children of the inserted root node
 		CtVirtualElement superInterfaceRoot = (CtVirtualElement) diff.getRootOperations().get(0).getSrcNode();

--- a/src/test/resources/examples/spoon.json
+++ b/src/test/resources/examples/spoon.json
@@ -7,7 +7,7 @@
       "type": "Class",
       "children": [
         {
-          "label": "SuperInterfaces",
+          "label": "",
           "type": "SUPER_INTERFACES",
           "children": [
             {
@@ -43,7 +43,7 @@
           "type": "SUPER_TYPE",
           "children": [
             {
-              "label": "SuperInterfaces",
+              "label": "",
               "type": "SUPER_INTERFACES",
               "children": [
                 {


### PR DESCRIPTION
Root nodes don't need a label because their label can never change so it's better to put an empty string. Putting an empty string also reduces execution time. Reference: https://github.com/SpoonLabs/gumtree-spoon-ast-diff/pull/198#discussion_r714471050.