### PR TITLE
chore: fix deployment script with Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,9 +19,10 @@ jobs:
         # Reference: https://github.com/lewagon/wait-on-check-action#running-workflow-name
         running-workflow-name: 'Publish package'
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v2
     - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
         java-version: 11
     - name: Start deployment
-      run: .buildscript/deploy_to_maven.sh
+      run: ./.buildscript/deploy_to_maven.sh


### PR DESCRIPTION
The deployment script was not executing in https://github.com/SpoonLabs/gumtree-spoon-ast-diff/commit/b111c7d80c3a314f6173addf6bd98e6a4fb76b17 because I didn't use the [checkout action](https://github.com/actions/checkout). Thus, the workflow wasn't able to locate the `deploy_to_maven.sh` script.