### PR TITLE
docs: update badges for build status and deployment status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://travis-ci.org/SpoonLabs/gumtree-spoon-ast-diff.svg?branch=master)](https://travis-ci.org/SpoonLabs/gumtree-spoon-ast-diff)
+[![Build Status](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/actions/workflows/ci.yml/badge.svg)](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/actions/workflows/ci.yml)
+[![Latest Deployment Status](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/actions/workflows/publish.yml/badge.svg?branch=master)](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/actions/workflows/publish.yml)
 
 Gumtree Spoon AST Diff
 ======================


### PR DESCRIPTION
The current badges were outdated since we don't use Travis now.