### PR TITLE
chore: configure execution of workflows on PRs from forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,12 @@
 name: CI
-on: push
+
+on:
+  pull_request:
+    branches:
+      - master
+  push:
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
The changes enable the execution of workflows on PRs from forks. See https://github.com/SpoonLabs/gumtree-spoon-ast-diff/pull/202#issuecomment-936886526.

> Pull requests from forks absolutely do trigger workflows if the pull_request target is specified in the workflow file. Just look at Spoon!