### PR TITLE
feat: produce fine-grained AST diff for annotations

### DIFF
--- a/src/main/java/gumtree/spoon/builder/LabelFinder.java
+++ b/src/main/java/gumtree/spoon/builder/LabelFinder.java
@@ -140,7 +140,7 @@ class LabelFinder extends CtInheritanceScanner {
 
 	@Override
 	public <T extends Annotation> void visitCtAnnotation(CtAnnotation<T> annotation) {
-		label = annotation.toString();
+		label = annotation.getType().getQualifiedName();
 	}
 
 	@Override

--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -1,11 +1,15 @@
 package gumtree.spoon.builder;
 
+import java.lang.annotation.Annotation;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
 import com.github.gumtreediff.tree.Tree;
 
+import spoon.reflect.code.CtExpression;
+import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtMethod;
 import spoon.reflect.declaration.CtModifiable;
@@ -156,5 +160,25 @@ public class NodeCreator extends CtInheritanceScanner {
 			builder.addSiblingNode(thrownTypeRoot);
 		}
 		super.visitCtMethod(e);
+	}
+
+	@Override
+	public <A extends Annotation> void visitCtAnnotation(CtAnnotation<A> annotation) {
+		if (annotation.getValues().isEmpty()) {
+			return;
+		}
+
+		final String virtualNodeDescription = "AnnotationValues_" + getClassName(annotation.getClass().getSimpleName());
+		Tree annotationNode = builder.createNode(virtualNodeDescription, "");
+
+		annotationNode.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT,
+				new CtVirtualElement(virtualNodeDescription, annotation, annotation.getValues().entrySet(), CtRole.VALUE));
+
+		for (Map.Entry<String, CtExpression> entry: annotation.getValues().entrySet()) {
+			Tree annotationValueNode = builder.createNode("ANNOTATION_VALUE", entry.toString());
+			annotationNode.addChild(annotationValueNode);
+			annotationValueNode.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, new CtWrapper(entry, annotation, CtRole.VALUE));
+		}
+		builder.addSiblingNode(annotationNode);
 	}
 }

--- a/src/main/java/gumtree/spoon/builder/TreeScanner.java
+++ b/src/main/java/gumtree/spoon/builder/TreeScanner.java
@@ -10,7 +10,9 @@ import com.github.gumtreediff.tree.Type;
 
 import spoon.reflect.code.CtBlock;
 import spoon.reflect.code.CtCase;
+import spoon.reflect.code.CtLiteral;
 import spoon.reflect.code.CtStatementList;
+import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtReference;
@@ -81,6 +83,11 @@ public class TreeScanner extends CtScanner {
 
 		if (element instanceof CtReference && element.getRoleInParent() == CtRole.SUPER_TYPE) {
 			return false;
+		}
+
+		// We need to ignore the literal in the annotation value because we store them in CtWrapper
+		if (element instanceof CtLiteral<?> && element.getParent() instanceof CtAnnotation) {
+			return true;
 		}
 
 		return element.isImplicit() || element instanceof CtReference;

--- a/src/test/java/gumtree/spoon/TreeTest.java
+++ b/src/test/java/gumtree/spoon/TreeTest.java
@@ -542,7 +542,7 @@ public class TreeTest {
 		Tree root = scanner.getTree(spoonType);
 
 		Tree annotationNode = root.getChild(0).getChild(0).getChild(2);
-		assertEquals("@java.lang.Override", annotationNode.getLabel());
+		assertEquals("java.lang.Override", annotationNode.getLabel());
 	}
 
 	@Test

--- a/src/test/java/gumtree/spoon/diff/DiffTest.java
+++ b/src/test/java/gumtree/spoon/diff/DiffTest.java
@@ -14,6 +14,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import gumtree.spoon.builder.CtVirtualElement;
@@ -357,5 +358,19 @@ public class DiffTest {
 		List<?> actualValues = Arrays.asList(annotation.getChildren().toArray());
 		assertThat(new ArrayList<>(expectedValues.entrySet()), equalTo(actualValues));
 
+	}
+
+	// ToDo
+	@Ignore("Can be fixed after #154")
+	@Test
+	public void test_diffOfAnnotationValues_updateMethod() throws Exception {
+		File left = new File("src/test/resources/examples/annotationValues/updateMethod/left.java");
+		File right = new File("src/test/resources/examples/annotationValues/updateMethod/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperations(OperationKind.Update, "AnnotationMethod", "a", "b"));
+		assertTrue(diff.containsOperations(OperationKind.Update, "ANNOTATION_VALUE", "a=\"1\"", "b=\"1\""));
 	}
 }

--- a/src/test/java/gumtree/spoon/diff/DiffTest.java
+++ b/src/test/java/gumtree/spoon/diff/DiffTest.java
@@ -1,12 +1,18 @@
 package gumtree.spoon.diff;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.junit.Test;
 
@@ -15,6 +21,7 @@ import gumtree.spoon.AstComparator;
 import gumtree.spoon.diff.operations.Operation;
 import gumtree.spoon.diff.operations.OperationKind;
 import spoon.Launcher;
+import spoon.reflect.code.CtLiteral;
 import spoon.reflect.declaration.CtClass;
 
 /**
@@ -333,5 +340,22 @@ public class DiffTest {
 		assertEquals(2, diff.getRootOperations().size());
 		assertTrue(diff.containsOperation(OperationKind.Insert, "ANNOTATION_VALUE", "type=\"int\""));
 		assertTrue(diff.containsOperation(OperationKind.Insert, "ANNOTATION_VALUE", "value=\"41\""));
+	}
+
+	@Test
+	public void test_diffOfAnnotations_firstInsertOfValue() throws Exception {
+		File left = new File("src/test/resources/examples/annotationValues/firstInsert/left.java");
+		File right = new File("src/test/resources/examples/annotationValues/firstInsert/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+
+		assertEquals(1, diff.getRootOperations().size());
+		Map<String, CtLiteral<?>> expectedValues = new LinkedHashMap<>();
+		expectedValues.put("since", new Launcher().getFactory().createLiteral("4.2"));
+
+		CtVirtualElement annotation = (CtVirtualElement) diff.getRootOperations().get(0).getSrcNode();
+		List<?> actualValues = Arrays.asList(annotation.getChildren().toArray());
+		assertThat(new ArrayList<>(expectedValues.entrySet()), equalTo(actualValues));
+
 	}
 }

--- a/src/test/java/gumtree/spoon/diff/DiffTest.java
+++ b/src/test/java/gumtree/spoon/diff/DiffTest.java
@@ -322,4 +322,16 @@ public class DiffTest {
 				"java.lang.ClassCastException"
 		}, thrownTypeRoot.getChildren().stream().map(Object::toString).toArray());
 	}
+
+	@Test
+	public void test_diffOfAnnotations_insertionOfValues() throws Exception {
+		File left = new File("src/test/resources/examples/annotationValues/insert/left.java");
+		File right = new File("src/test/resources/examples/annotationValues/insert/right.java");
+
+		Diff diff = new AstComparator().compare(left, right);
+
+		assertEquals(2, diff.getRootOperations().size());
+		assertTrue(diff.containsOperation(OperationKind.Insert, "ANNOTATION_VALUE", "type=\"int\""));
+		assertTrue(diff.containsOperation(OperationKind.Insert, "ANNOTATION_VALUE", "value=\"41\""));
+	}
 }

--- a/src/test/resources/examples/annotationValues/firstInsert/left.java
+++ b/src/test/resources/examples/annotationValues/firstInsert/left.java
@@ -1,0 +1,4 @@
+class Test {
+    @Deprecated
+    public Test(int x) { }
+}

--- a/src/test/resources/examples/annotationValues/firstInsert/right.java
+++ b/src/test/resources/examples/annotationValues/firstInsert/right.java
@@ -1,0 +1,4 @@
+class Test {
+    @Deprecated(since = "4.2")
+    public Test(int x) { }
+}

--- a/src/test/resources/examples/annotationValues/insert/left.java
+++ b/src/test/resources/examples/annotationValues/insert/left.java
@@ -1,0 +1,13 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@interface Column {
+    int id();
+    String description();
+    String type() default "String";
+    String value() default "42"
+}
+
+@Column(id = 1, description = "blah")
+public class AnnotationValue { }

--- a/src/test/resources/examples/annotationValues/insert/right.java
+++ b/src/test/resources/examples/annotationValues/insert/right.java
@@ -1,0 +1,13 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@interface Column {
+    int id();
+    String description();
+    String type() default "String";
+    String value() default "42"
+}
+
+@Column(id = 1, type = "int", description = "blah", value = "41")
+public class AnnotationValue { }

--- a/src/test/resources/examples/annotationValues/updateMethod/left.java
+++ b/src/test/resources/examples/annotationValues/updateMethod/left.java
@@ -1,0 +1,10 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@interface Column {
+    String a();
+}
+
+@Column(a = "1")
+class A { }

--- a/src/test/resources/examples/annotationValues/updateMethod/right.java
+++ b/src/test/resources/examples/annotationValues/updateMethod/right.java
@@ -1,0 +1,10 @@
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@interface Column {
+    String b();
+}
+
+@Column(b = "1")
+class A { }


### PR DESCRIPTION
Fixes: #220 

The changes wrap values of `CtAnnotation` in `CtVirtualElement` which in turn wraps all the key-value pairs in `CtWrapper`. Note that this case is similar to how we deal with modifiers because values of annotation are not spoon nodes. They are of the form `Map.Entry<String, CtExpression>`.

However, there is one pending task before we move on to merging. ~The `rootOperations` also an update operation like in the linked issue along with two insert operations. The latter should not be reported because node in update operation is parent of the `srcNode`s in the insert operation. In my experience, the `ActionClassifier` should ignore the operation if a parent _at any level exists_. More technically, [this line](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/main/java/gumtree/spoon/diff/ActionClassifier.java#L75) should be modified to check for parent, grand-parent, and so on of `t`.~

EDIT:

A better way to deal with it would be to just remove the unnecessary update operation being computed. #125 keeps gaining priority. :exploding_head: 