### PR TITLE
refactor: remove null check for executable while visiting invocation

### DIFF
--- a/src/main/java/gumtree/spoon/builder/LabelFinder.java
+++ b/src/main/java/gumtree/spoon/builder/LabelFinder.java
@@ -42,22 +42,12 @@ class LabelFinder extends CtInheritanceScanner {
 
 	@Override
 	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
-		if (invocation.getExecutable() != null) {
-			CtTypeReference decl = invocation.getExecutable().getDeclaringType();
-			// label =
-			// (decl!=null?decl.getQualifiedName():"")+"#"+invocation.getExecutable().getSignature();
-			// label = (decl != null ? decl.getQualifiedName() : "") + "#" +
-			// invocation.getExecutable().getSimpleName();
-			label = invocation.getExecutable().getSimpleName();
-
-		}
+		label = invocation.getExecutable().getSimpleName();
 	}
 
 	@Override
 	public <T> void visitCtConstructorCall(CtConstructorCall<T> ctConstructorCall) {
-		if (ctConstructorCall.getExecutable() != null) {
-			label = ctConstructorCall.getExecutable().getSignature();
-		}
+		label = ctConstructorCall.getExecutable().getSignature();
 	}
 
 	@Override


### PR DESCRIPTION
It is not required to check if `Invocation.getExecutable` returns `null` because it never does. See the following two implementations of `getExecutable()`. Notice that it always assigns a default reference. 
1. https://github.com/INRIA/spoon/blob/8af9cceb0053ce109ebd0142f82daec5f928b970/src/main/java/spoon/support/reflect/code/CtConstructorCallImpl.java#L52-L60
2. https://github.com/INRIA/spoon/blob/8af9cceb0053ce109ebd0142f82daec5f928b970/src/main/java/spoon/support/reflect/code/CtInvocationImpl.java#L86-L94

