### PR TITLE
fix: ignore update operation in a child node has been inserted or deleted

### DIFF
--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -1499,11 +1499,11 @@ public class AstComparatorTest {
 		File fr = new File("src/test/resources/examples/t_228643/right_ScopePeer_1.4.java");
 		Diff result = diff.compare(fl, fr);
 
-		List<Operation> actions = result.getRootOperations();
+		List<Operation> actions = result.getUpdateOperations();
+		assertEquals(0, result.getRootOperations());
 		result.debugInformation();
 		assertEquals(1, actions.size());
-		assertTrue(
-				result.containsOperation(OperationKind.Update, "ConstructorCall", "org.apache.torque.util.Criteria()"));
+		assertTrue(result.containsUpdateOperation("ConstructorCall", CtRole.EXECUTABLE_REF,"org", "d"));
 	}
 
 	@Test

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -765,9 +765,10 @@ public class AstComparatorTest {
 
 		result.getRootOperations();
 		result.debugInformation();
-		List<Operation> actions = result.getRootOperations();
+		List<Operation> actions = result.getUpdateOperations();
 
-		assertEquals(actions.size(), 1);
+		assertEquals(0, result.getRootOperations().size());
+		assertEquals(1, actions.size());
 		assertTrue(result.containsOperation(OperationKind.Update, "ConstructorCall"));
 	}
 


### PR DESCRIPTION
```diff
- new org.apache.torque.util.Criteria()
+ new org.apache.torque.util.Criteria(0)
```
The edit script of the above diff contains an update operation and an insert. The expected behaviour is to only report an insertion of a literal. A possible solution could be to check for child operations of any operation before classifying it as a `UpdateOperation`.