### PR TITLE
Improve performance in the Test phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
           <!-- the following is required to have the same execution semantics as eclipse (hence all tests passing) -->
           <!-- the reason is that it switches Spoon in noclasspath or not for this particular file -->
           <useSystemClassLoader>false</useSystemClassLoader>
-          <forkCount>1</forkCount>
+          <forkCount>1.5C</forkCount>
         </configuration>
       </plugin>
 


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
