### PR TITLE
fix: differentiate `super` from `this` invocation

### DIFF
--- a/src/main/java/gumtree/spoon/builder/LabelFinder.java
+++ b/src/main/java/gumtree/spoon/builder/LabelFinder.java
@@ -21,6 +21,7 @@ import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.declaration.CtAnnotation;
 import spoon.reflect.declaration.CtNamedElement;
+import spoon.reflect.declaration.CtType;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtTypeReference;
 import spoon.reflect.visitor.CtInheritanceScanner;
@@ -42,7 +43,16 @@ class LabelFinder extends CtInheritanceScanner {
 
 	@Override
 	public <T> void visitCtInvocation(CtInvocation<T> invocation) {
-		label = invocation.getExecutable().getSimpleName();
+		if (invocation.getExecutable().isConstructor()) {
+			CtType<?> parentType = invocation.getParent(CtType.class);
+			if (parentType.getQualifiedName().equals(invocation.getExecutable().getDeclaringType().getQualifiedName())) {
+				label = "this";
+			} else {
+				label = "super";
+			}
+		} else {
+			label = invocation.getExecutable().getSimpleName();
+		}
 	}
 
 	@Override

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2140,8 +2140,8 @@ public class AstComparatorTest {
 	@Test
 	public void thisAndSuperShouldResultInAnASTDiff() {
 		// arrange
-		String c3= " class X { public  X() { this(); } }";
-		String c4= " class X { public X() { super();} }";
+		String c3 = "class X { public  X() { this(); } }";
+		String c4 = "class X { public X() { super();} }";
 		AstComparator comparator = new AstComparator();
 
 		// act

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2136,4 +2136,18 @@ public class AstComparatorTest {
 		assertEquals(deleteOpt.get().getNode().toString(), moveOpt.get().getNode().toString());
 
 	}
+
+	@Test
+	public void thisAndSuperShouldResultInAnASTDiff() throws Exception {
+		// arrange
+		String c3= " class X { public  X() { this(); } }";
+		String c4= " class X { public X() { super();} }";
+		AstComparator comparator = new AstComparator();
+
+		// act
+		Diff diff = comparator.compare(c3, c4);
+
+		// assert
+		assertTrue(diff.containsOperations(OperationKind.Update, "Invocation", "this", "super"));
+	}
 }

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2138,7 +2138,7 @@ public class AstComparatorTest {
 	}
 
 	@Test
-	public void thisAndSuperShouldResultInAnASTDiff() throws Exception {
+	public void thisAndSuperShouldResultInAnASTDiff() {
 		// arrange
 		String c3= " class X { public  X() { this(); } }";
 		String c4= " class X { public X() { super();} }";

--- a/src/test/resources/examples/spoon.json
+++ b/src/test/resources/examples/spoon.json
@@ -262,7 +262,7 @@
               ]
             },
             {
-              "label": "\u003cinit\u003e",
+              "label": "super",
               "type": "Invocation",
               "children": [
                 {


### PR DESCRIPTION
Fix #247 

Initially a diff between `super` and `this` was disregarded because both of those invocations were assigned the label `<init>`. The changes proposed in this PR assign `super` and `this` labels to the respective nodes.