### PR TITLE
feat: report AST diff when expression is type cast

### DIFF
--- a/src/main/java/gumtree/spoon/builder/NodeCreator.java
+++ b/src/main/java/gumtree/spoon/builder/NodeCreator.java
@@ -9,13 +9,7 @@ import java.util.TreeSet;
 import com.github.gumtreediff.tree.Tree;
 
 import spoon.reflect.code.CtExpression;
-import spoon.reflect.declaration.CtAnnotation;
-import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtMethod;
-import spoon.reflect.declaration.CtModifiable;
-import spoon.reflect.declaration.CtTypeInformation;
-import spoon.reflect.declaration.CtVariable;
-import spoon.reflect.declaration.ModifierKind;
+import spoon.reflect.declaration.*;
 import spoon.reflect.path.CtRole;
 import spoon.reflect.reference.CtActualTypeContainer;
 import spoon.reflect.reference.CtTypeReference;
@@ -180,5 +174,20 @@ public class NodeCreator extends CtInheritanceScanner {
 			annotationValueNode.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, new CtWrapper(entry, annotation, CtRole.VALUE));
 		}
 		builder.addSiblingNode(annotationNode);
+	}
+
+	@Override
+	public <T> void scanCtTypedElement(CtTypedElement<T> e) {
+		if (e instanceof CtExpression) {
+			CtExpression<?> expression = (CtExpression<?>) e;
+
+			for (CtTypeReference<?> ctTypeCast : expression.getTypeCasts()) {
+				Tree typeCast = builder.createNode("TYPE_CAST", ctTypeCast.getQualifiedName());
+				typeCast.setMetadata(SpoonGumTreeBuilder.SPOON_OBJECT, ctTypeCast);
+				ctTypeCast.putMetadata(SpoonGumTreeBuilder.GUMTREE_NODE, typeCast);
+				computeTreeOfTypeReferences(ctTypeCast, typeCast);
+				builder.addSiblingNode(typeCast);
+			}
+		}
 	}
 }

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2150,4 +2150,17 @@ public class AstComparatorTest {
 		// assert
 		assertTrue(diff.containsOperations(OperationKind.Update, "Invocation", "this", "super"));
 	}
+
+	@Test
+	public void typeCastsShouldBeReportedInASTDiff() throws Exception {
+		// arrange
+		File left = new File("src/test/resources/examples/type-cast/left.java");
+		File right = new File("src/test/resources/examples/type-cast/right.java");
+
+		// act
+		Diff diff = new AstComparator().compare(left, right);
+
+		// assert
+		assertTrue(diff.containsOperation(OperationKind.Insert, "TYPE_CAST", "double"));
+	}
 }

--- a/src/test/resources/examples/type-cast/left.java
+++ b/src/test/resources/examples/type-cast/left.java
@@ -1,0 +1,7 @@
+class TypeCast {
+    public static void main(String[] args) {
+        for (int i=0; i<10; ++i) {
+            System.out.println(i);
+        }
+    }
+}

--- a/src/test/resources/examples/type-cast/right.java
+++ b/src/test/resources/examples/type-cast/right.java
@@ -1,0 +1,7 @@
+class TypeCast {
+    public static void main(String[] args) {
+        for (int i=0; i<10; ++i) {
+            System.out.println((double) i);
+        }
+    }
+}


### PR DESCRIPTION
Currently, gumtree-spoon reported no AST diff for the following diff:
```diff
class TypeCast {
    public static void main(String[] args) {
        for (int i=0; i<10; ++i) {
-           System.out.println(i);
+           System.out.println((double) i);
        }
    }
}
```
This happened because we ignored the type casts in this [function](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/69c1b4b2dbfd8b23b3da1d8c2d0250a2e2409e2e/src/main/java/gumtree/spoon/builder/TreeScanner.java#L76). However, we need to handle them and add them as nodes in the `ITree`.