### PR TITLE
chore: update spoon to 10.2.0-beta-15

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>fr.inria.gforge.spoon</groupId>
       <artifactId>spoon-core</artifactId>
-      <version>10.1.1</version>
+      <version>10.2.0-beta-15</version>
     </dependency>
     <dependency>
       <groupId>com.github.gumtreediff</groupId>

--- a/src/test/resources/examples/annotationValues/insert/left.java
+++ b/src/test/resources/examples/annotationValues/insert/left.java
@@ -1,6 +1,9 @@
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+@Column(id = 1, description = "blah")
+public class AnnotationValue { }
+
 @Target({ElementType.TYPE})
 @interface Column {
     int id();
@@ -8,6 +11,3 @@ import java.lang.annotation.Target;
     String type() default "String";
     String value() default "42"
 }
-
-@Column(id = 1, description = "blah")
-public class AnnotationValue { }

--- a/src/test/resources/examples/annotationValues/insert/right.java
+++ b/src/test/resources/examples/annotationValues/insert/right.java
@@ -1,6 +1,9 @@
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 
+@Column(id = 1, type = "int", description = "blah", value = "41")
+public class AnnotationValue { }
+
 @Target({ElementType.TYPE})
 @interface Column {
     int id();
@@ -8,6 +11,3 @@ import java.lang.annotation.Target;
     String type() default "String";
     String value() default "42"
 }
-
-@Column(id = 1, type = "int", description = "blah", value = "41")
-public class AnnotationValue { }


### PR DESCRIPTION
Fixes #253 

The build was failing because the Jenkins build pulled the latest SNAPSHOT version of Spoon and it had the patch in [this commit](https://github.com/INRIA/spoon/commit/1ec339d04d9521593df7dea2dce1d263a74d2b9f). This caused a test failure in our project because the incorrect `CtType`s were being compared for AST difference.

I have fixed the failure by modifying the test so that the correct `CtType` is picked up. However, we should configure in Jenkins that it should use the version provided in POM. As of now, it uses [`inject_spoon_snapshot.py`](https://spoon.gforge.inria.fr/jenkins/inject_spoon_snapshot.py) to specify the version of Spoon the build is supposed to use. Is that intended, @monperrus ? I am assuming it is there so that gumtree-spoon maintainers become aware of updating Spoon once in a while.

