### PR TITLE
ci: fix release script

### DIFF
--- a/.buildscript/deploy_to_maven.sh
+++ b/.buildscript/deploy_to_maven.sh
@@ -15,8 +15,7 @@ gpg --fast-import spoonbot.gpg
 # getting the previous version on Maven Central
 # for some reasons, some versions don't get index by search.maven.org/solrsearch/, and it break the build
 # so we have to roll our own: https://gist.github.com/monperrus/9ee373e2500e40b634f8daf707f6ad2a
-# PREVIOUS_MAVEN_CENTRAL_VERSION=`curl "http://search.maven.org/solrsearch/select?q=a:gumtree-spoon-ast-diff+g:fr.inria.gforge.spoon.labs&rows=20&wt=json" | jq -r .response.docs[0].latestVersion | egrep -o "[0-9]+$"`
-PREVIOUS_MAVEN_CENTRAL_VERSION=`curl "https://www.monperrus.net/martin/last-version-maven.py?groupId=fr.inria.gforge.spoon.labs&artifactId=gumtree-spoon-ast-diff" | egrep -o "[0-9]+$"`
+PREVIOUS_MAVEN_CENTRAL_VERSION=`curl "http://search.maven.org/solrsearch/select?q=a:gumtree-spoon-ast-diff+g:fr.inria.gforge.spoon.labs&rows=20&wt=json" -L | jq -r ".response.docs[0].latestVersion" | egrep -o "[0-9]+$"`
 
 # and incrementing it
 mvn versions:set -DnewVersion=1.$((PREVIOUS_MAVEN_CENTRAL_VERSION+1))


### PR DESCRIPTION
1. Make `cURL` follow redirects. `search.maven.org` is redirected to `central.sonatype.com`.
2. Fix `jq` input.