### PR TITLE
fix some "no AST change" when there are syntax errors

### DIFF
--- a/src/main/java/gumtree/spoon/AstComparator.java
+++ b/src/main/java/gumtree/spoon/AstComparator.java
@@ -57,7 +57,13 @@ public class AstComparator {
 	 * compares two java files
 	 */
 	public Diff compare(File f1, File f2) throws Exception {
-		return this.compare(getCtType(f1), getCtType(f2));
+		CtType<?> ctType1 = getCtType(f1);
+		CtType<?> ctType2 = getCtType(f2);
+		if (ctType1 == null || ctType2 == null) {
+			return null;
+		} else {
+			return compare(ctType1, ctType2);
+		}
 	}
 	
 	/**


### PR DESCRIPTION
In cases where there are some syntax errors, gumtree-spoon-ast-diff outputs "no AST change"

This PR fixes that.
Right now, only the most serious cases are fixed.
If there are subtle syntax errors like missing a ";" or ")" and the rest matches, it will still output "no AST change" :/