### PR TITLE
test: Adding a couple of test cases for anonymous class

### DIFF
--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2125,7 +2125,7 @@ public class AstComparatorTest {
 	@Test
 	public void testAnonymousClassDifferentInsertion() throws Exception {
 		// GitHub Issue: https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/347
-		// Inserts an anonymous class that is slightly different from an anonymous class that
+		// Inserts an anonymous class that has a different body from the anonymous class that
 		// is already present elsewhere in the code (the one that is already present is NOT empty)
 		AstComparator diff = new AstComparator();
 		File fl = new File("src/test/resources/examples/issue347/DifferentInsertionFirst.java");

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2101,4 +2101,44 @@ public class AstComparatorTest {
 
 	}
 
+	@Test
+	public void testAnonymousClassSameInsertion() throws Exception {
+		// GitHub Issue: https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/347
+		// Inserts an anonymous class that is the *exact* same as the one that is present already
+		// in the file (they are both empty in this case)
+		AstComparator diff = new AstComparator();
+		File fl = new File("src/test/resources/examples/issue347/SameInsertionFirst.java");
+		File fr = new File("src/test/resources/examples/issue347/SameInsertionSecond.java");
+
+		System.setProperty("nolabel", "true");
+		Diff result = diff.compare(fl, fr);
+		// Setting this back to "false" so it does not interfere with other tests
+		System.setProperty("nolabel", "false");
+
+		assertEquals(1, result.getRootOperations().size());
+		// This call to "containsOperation" only seems to check rootOperations at the moment
+		// For context: "RootOperations" are also the ones that are seem to be printed in the toString()
+		// 				for the diff, NOT `allOperations`.
+		assertTrue(result.containsOperation(OperationKind.Insert, "Invocation", "Invocation"));
+	}
+
+	@Test
+	public void testAnonymousClassDifferentInsertion() throws Exception {
+		// GitHub Issue: https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/347
+		// Inserts an anonymous class that is slightly different from an anonymous class that
+		// is already present elsewhere in the code (the one that is already present is NOT empty)
+		AstComparator diff = new AstComparator();
+		File fl = new File("src/test/resources/examples/issue347/DifferentInsertionFirst.java");
+		File fr = new File("src/test/resources/examples/issue347/DifferentInsertionSecond.java");
+
+		// Explicitly setting to "nolabel" mode gives the expected diff
+		System.setProperty("nolabel", "true");
+		Diff result = diff.compare(fl, fr);
+		// Setting this back to "false" so it does not interfere with other tests
+		System.setProperty("nolabel", "false");
+
+		assertEquals(1, result.getRootOperations().size());
+		assertTrue(result.containsOperation(OperationKind.Insert, "Invocation", "Invocation"));
+	}
+
 }

--- a/src/test/resources/examples/issue347/DifferentInsertionFirst.java
+++ b/src/test/resources/examples/issue347/DifferentInsertionFirst.java
@@ -1,0 +1,11 @@
+public class SpoonInvestigation {
+    private void x(){
+        sleep(1);
+    }
+    public void y() {
+        startServer(new HttpServlet(){
+            @Override
+            protected void doGet(){}
+        });
+    }
+}

--- a/src/test/resources/examples/issue347/DifferentInsertionSecond.java
+++ b/src/test/resources/examples/issue347/DifferentInsertionSecond.java
@@ -1,0 +1,12 @@
+public class SpoonInvestigation {
+    private void x(){
+        sleep(1);
+        startServer(new HttpServlet(){});
+    }
+    public void y() {
+        startServer(new HttpServlet(){
+            @Override
+            protected void doGet(){}
+        });
+    }
+}

--- a/src/test/resources/examples/issue347/SameInsertionFirst.java
+++ b/src/test/resources/examples/issue347/SameInsertionFirst.java
@@ -1,0 +1,8 @@
+public class SpoonInvestigation {
+    private void x(){
+        sleep(1);
+    }
+    public void y() {
+        startServer(new HttpServlet(){});
+    }
+}

--- a/src/test/resources/examples/issue347/SameInsertionSecond.java
+++ b/src/test/resources/examples/issue347/SameInsertionSecond.java
@@ -1,0 +1,9 @@
+public class SpoonInvestigation {
+    private void x(){
+        sleep(1);
+        startServer(new HttpServlet(){});
+    }
+    public void y() {
+        startServer(new HttpServlet(){});
+    }
+}


### PR DESCRIPTION
See https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/347

This adds a couple of test cases to show that setting the `nolabel` property to true before calling the `Diff` ignores the labels and gives the expected output for the cases similar to the example test case(s) presented in the issue. 

## Some Notes

## On the handling of the `nolabel` property
There is a need to manually set and unset the `nolabel` system property before and after (respectively) each of the 2 test cases have computed their diff because quite a lot (around 70) test cases *fail* if the `nolabel` property is set to `true`. 

I am hopeful that these tests are not run "in parallel" -- ie, the property is set to `true`, and at the same time, another test is also executing (before the property could be "unset" again), which fails because of this property being `true`. 

If something like this happens, then these test cases might result in flaky scenarios, and we should reconsider adding them. In the few times I have run this locally, it _seems_ to not be the case (ie, tests pass)

## On the assertions being made
Looking at another test in the file, I believe that the content of the `Diff` object that is most relevant is the `rootOperations`, so that is what I am asserting contains 1 element here (also seems to be the thing printed when printing the `diff` object). 

Additionally, I was not quite sure how to make an assertion on the `result` object's operations. So, I looked at another test and followed a similar pattern. I did however set a breakpoint on the `containsOperation` call to examine the properties of the single `rootOperation` and set the expected values in the assertion accordingly. 

**Please let me know if we should be asserting something else here, or if more assertions are needed (same goes for other test cases that might need adding) !** 🙏🏽

@monperrus @algomaster99 