### PR TITLE
fix: using empty string as label for an anonymous CtClass

### DIFF
--- a/src/main/java/gumtree/spoon/builder/LabelFinder.java
+++ b/src/main/java/gumtree/spoon/builder/LabelFinder.java
@@ -20,6 +20,7 @@ import spoon.reflect.code.CtUnaryOperator;
 import spoon.reflect.code.CtVariableAccess;
 import spoon.reflect.code.CtWhile;
 import spoon.reflect.declaration.CtAnnotation;
+import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtNamedElement;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.path.CtRole;
@@ -33,7 +34,11 @@ class LabelFinder extends CtInheritanceScanner {
 
 	@Override
 	public void scanCtNamedElement(CtNamedElement e) {
-		label = e.getSimpleName();
+		if (e instanceof CtClass && ((CtClass<?>) e).isAnonymous()) {
+			label = "";
+		} else {
+			label = e.getSimpleName();
+		}
 	}
 
 	@Override

--- a/src/test/java/gumtree/spoon/AstComparatorTest.java
+++ b/src/test/java/gumtree/spoon/AstComparatorTest.java
@@ -2110,16 +2110,13 @@ public class AstComparatorTest {
 		File fl = new File("src/test/resources/examples/issue347/SameInsertionFirst.java");
 		File fr = new File("src/test/resources/examples/issue347/SameInsertionSecond.java");
 
-		System.setProperty("nolabel", "true");
 		Diff result = diff.compare(fl, fr);
-		// Setting this back to "false" so it does not interfere with other tests
-		System.setProperty("nolabel", "false");
 
 		assertEquals(1, result.getRootOperations().size());
 		// This call to "containsOperation" only seems to check rootOperations at the moment
 		// For context: "RootOperations" are also the ones that are seem to be printed in the toString()
 		// 				for the diff, NOT `allOperations`.
-		assertTrue(result.containsOperation(OperationKind.Insert, "Invocation", "Invocation"));
+		assertTrue(result.containsOperation(OperationKind.Insert, "Invocation", "startServer"));
 	}
 
 	@Test
@@ -2131,14 +2128,10 @@ public class AstComparatorTest {
 		File fl = new File("src/test/resources/examples/issue347/DifferentInsertionFirst.java");
 		File fr = new File("src/test/resources/examples/issue347/DifferentInsertionSecond.java");
 
-		// Explicitly setting to "nolabel" mode gives the expected diff
-		System.setProperty("nolabel", "true");
 		Diff result = diff.compare(fl, fr);
-		// Setting this back to "false" so it does not interfere with other tests
-		System.setProperty("nolabel", "false");
 
 		assertEquals(1, result.getRootOperations().size());
-		assertTrue(result.containsOperation(OperationKind.Insert, "Invocation", "Invocation"));
+		assertTrue(result.containsOperation(OperationKind.Insert, "Invocation", "startServer"));
 	}
 
 }


### PR DESCRIPTION
See https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/347

This should use an empty string as the label for an anonymous class. Initially I tried using the checksum of the pretty-printed anonymous class contents like so (these additions were in `LabelFinder.java`): 
```java
// ... other content
	private String getChecksum(String input) {
		Checksum crc32 = new CRC32();
		byte[] bytes = input.getBytes();
		crc32.update(bytes, 0, bytes.length);
		return Long.toHexString(crc32.getValue());
	}

        @Override
	public void scanCtNamedElement(CtNamedElement e) {
		if (e instanceof CtClass && ((CtClass<?>) e).isAnonymous()) {			
			label = getChecksum(e.prettyprint());
		} else {
			label = e.getSimpleName();
		}
	}
// ... other content
```
Even though it seems to resolve the issue in https://github.com/SpoonLabs/gumtree-spoon-ast-diff/issues/347 (verified with the passing of the test cases added in https://github.com/SpoonLabs/gumtree-spoon-ast-diff/pull/349 and modified here), it failed 3 other existing test cases. One of them was `test_action_RootOrder` in [`DiffTest.java`](https://github.com/SpoonLabs/gumtree-spoon-ast-diff/blob/master/src/test/java/gumtree/spoon/diff/DiffTest.java#L164). 

The issue for `test_action_RootOrder` seems to be that an _extra_ diff is generated for an update to an existing anonymous class. So this particular test generates 3 diffs: 1 update for the entire anonymous class (unexpected), and the 2 diffs for the new inserts (expected). 

This might be because the contents of the class changed which cause the checksum (and thus the label) to change, causing an extra update generation. 

Using a local "nolabel" mode however, where the label for an anonymous class is an empty string, seems to work for _all_ test cases: 
```
[...other test output]
[INFO] 
[INFO] Results:
[INFO] 
[WARNING] Tests run: 197, Failures: 0, Errors: 0, Skipped: 3
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  18.307 s
[INFO] Finished at: 2025-04-03T11:21:46+02:00
[INFO] ------------------------------------------------------------------------
```

cc @monperrus @algomaster99 